### PR TITLE
Fix installation bug in cmakelist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ examples/test.exe
 output/results
 output/*.dat
 inc/adani/version.h
+bin/adani-config
+bin/adani.pc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ option(PYTHON_ONLY "Compiles only for python." OFF)
 
 # pybind11
 if(PYTHON_ONLY)
+    find_package (Python3 REQUIRED)
     if(SKBUILD)
     message("Found skbuild")
         execute_process(
@@ -90,7 +91,6 @@ if(PYTHON_ONLY)
         src/SplittingFunctions.cc
     )
     target_link_libraries(_core PRIVATE GSL::gsl GSL::gslcblas)
-    # find_package (Python3 REQUIRED)
     target_compile_definitions(_core PRIVATE VERSION_INFO=${PROJECT_VERSION})
     install(TARGETS _core DESTINATION .)
 
@@ -114,12 +114,12 @@ else(PYTHON_ONLY)
 
     # define libraries to be linked
     target_link_libraries(adani GSL::gsl GSL::gslcblas)
-    # install(TARGETS adani RUNTIME DESTINATION bin LIBRARY DESTINATION lib)
 
     # install
     install(FILES ${PROJECT_SOURCE_DIR}/bin/adani-config
     DESTINATION bin PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
     install(FILES ${PROJECT_SOURCE_DIR}/bin/adani.pc DESTINATION lib/pkgconfig)
     install(DIRECTORY inc/adani DESTINATION include)
-    install(TARGETS adani LIBRARY DESTINATION lib)
+    install(TARGETS adani DESTINATION bin LIBRARY DESTINATION lib)
+
 endif (PYTHON_ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,23 +1,37 @@
 # BASIC DEFINITIONS ========================================================================
 
 # define minimum version of cmake
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.15..3.22)
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "Setting build type to 'Release' as none was specified.")
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+    # Set the possible values of build type for cmake-gui
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
+        "MinSizeRel" "RelWithDebInfo")
+endif()
 
 # define project name and its language
-project(adani CXX Fortran)
+project(adani VERSION 0.10) # el diez
 
 # define c++ standard and issue all the warning demanded by this standard
-set(CMAKE_BUILD_TYPE Release)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -fPIC")
+enable_language(Fortran)
 set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fPIC")
 
 if (NOT DEFINED CMAKE_MACOSX_RPATH)
     set(CMAKE_MACOSX_RPATH 0)
 endif()
 
-set(adani_VERSION 0.10) # el diez
+# Configuration script
+set(prefix ${CMAKE_INSTALL_PREFIX})
+set(exec_prefix "${prefix}")
+set(includedir "${prefix}/include")
+set(libdir "${prefix}/lib")
+
+include_directories(${PROJECT_SOURCE_DIR}/inc)
 
 # export version to file
 configure_file(
@@ -25,46 +39,87 @@ configure_file(
     "${PROJECT_SOURCE_DIR}/inc/adani/version.h"
 )
 
-# Configuration script
-set(prefix ${CMAKE_INSTALL_PREFIX})
-set(includedir "${prefix}/include")
-set(libdir "${prefix}/lib")
-configure_file("${PROJECT_SOURCE_DIR}/bin/adani-config.in" "${PROJECT_BINARY_DIR}/bin/adani-config")
-include_directories(${PROJECT_SOURCE_DIR}/inc)
-
+configure_file(
+    "${PROJECT_SOURCE_DIR}/bin/adani-config.in"
+    "${PROJECT_SOURCE_DIR}/bin/adani-config"
+)
+configure_file(
+    "${PROJECT_SOURCE_DIR}/bin/adani.pc.in"
+    "${PROJECT_SOURCE_DIR}/bin/adani.pc"
+)
 # find gsl
 find_package(GSL REQUIRED)
 
 # FINALIZE ==================================================================================
 
 # generate list of source files
-file(GLOB_RECURSE  source_files src/*)
+# file(GLOB_RECURSE  source_files src/*)
 
-# define target library
-set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
+# # define target library
+# set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
 
-add_library(adani SHARED ${source_files})
-
-# define libraries to be linked
-target_link_libraries(adani GSL::gsl GSL::gslcblas)
+option(PYTHON_ONLY "Compiles only for python." OFF)
 
 # pybind11
-find_package(pybind11 QUIET)
-if (pybind11_FOUND)
-    pybind11_add_module(adanipy pywrap/pywrap.cc)
-    target_link_libraries(adanipy PRIVATE adani)
-    find_package (Python3 REQUIRED)
-    execute_process(COMMAND "${Python3_EXECUTABLE}" -c "import distutils.sysconfig; print(distutils.sysconfig.get_python_lib(prefix='${CMAKE_INSTALL_PREFIX}', plat_specific=True), end = '')" OUTPUT_VARIABLE PYTHON_INSTALLATION_PATH)
-    install(TARGETS adanipy LIBRARY DESTINATION "${PYTHON_INSTALLATION_PATH}")
-else (pybind11_FOUND)
-    message ("-- pybind11 not found. The python wrapper will not be built.")
-endif (pybind11_FOUND)
+if(PYTHON_ONLY)
+    if(SKBUILD)
+    message("Found skbuild")
+        execute_process(
+        COMMAND "${PYTHON_EXECUTABLE}" -c
+                "import pybind11; print(pybind11.get_cmake_dir())"
+        OUTPUT_VARIABLE _tmp_dir
+        OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ECHO STDOUT)
+        list(APPEND CMAKE_PREFIX_PATH "${_tmp_dir}")
+    endif(SKBUILD)
+    find_package(pybind11 CONFIG REQUIRED)
+    pybind11_add_module(
+        _core MODULE
+        pywrap/pywrap.cc
+        src/ApproximateCoefficientFunctions.cc
+        src/MassiveCoefficientFunctions.cc
+        src/ThresholdCoefficientFunctions.cc
+        src/AsymptoticCoefficientFunctions.cc
+        src/MasslessCoefficientFunctions.cc
+        src/Convolutions.cc
+        src/MatchingConditions.cc
+        src/hplog.f
+        src/HighEnergyCoefficientFunctions.cc
+        src/SpecialFunctions.cc
+        src/hqcoef.f
+        src/HighScaleCoefficientFunctions.cc
+        src/SplittingFunctions.cc
+    )
+    target_link_libraries(_core PRIVATE GSL::gsl GSL::gslcblas)
+    # find_package (Python3 REQUIRED)
+    target_compile_definitions(_core PRIVATE VERSION_INFO=${PROJECT_VERSION})
+    install(TARGETS _core DESTINATION .)
 
-# install
-option(PYTHON_ONLY "Compiles only for python." OFF)
-if (NOT PYTHON_ONLY)
-    install(TARGETS adani RUNTIME DESTINATION bin LIBRARY DESTINATION lib)
+else(PYTHON_ONLY)
+    add_library(
+        adani SHARED
+        src/ApproximateCoefficientFunctions.cc
+        src/MassiveCoefficientFunctions.cc
+        src/ThresholdCoefficientFunctions.cc
+        src/AsymptoticCoefficientFunctions.cc
+        src/MasslessCoefficientFunctions.cc
+        src/Convolutions.cc
+        src/MatchingConditions.cc
+        src/hplog.f
+        src/HighEnergyCoefficientFunctions.cc
+        src/SpecialFunctions.cc
+        src/hqcoef.f
+        src/HighScaleCoefficientFunctions.cc
+        src/SplittingFunctions.cc
+    )
+
+    # define libraries to be linked
+    target_link_libraries(adani GSL::gsl GSL::gslcblas)
+    # install(TARGETS adani RUNTIME DESTINATION bin LIBRARY DESTINATION lib)
+
+    # install
+    install(FILES ${PROJECT_SOURCE_DIR}/bin/adani-config
+    DESTINATION bin PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+    install(FILES ${PROJECT_SOURCE_DIR}/bin/adani.pc DESTINATION lib/pkgconfig)
     install(DIRECTORY inc/adani DESTINATION include)
-    install(FILES ${PROJECT_BINARY_DIR}/bin/adani-config DESTINATION bin
-    PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
-endif (NOT PYTHON_ONLY)
+    install(TARGETS adani LIBRARY DESTINATION lib)
+endif (PYTHON_ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,12 +62,11 @@ option(PYTHON_ONLY "Compiles only for python." OFF)
 
 # pybind11
 if(PYTHON_ONLY)
-    find_package (Python3 REQUIRED)
     if(SKBUILD)
     message("Found skbuild")
         execute_process(
-        COMMAND "${PYTHON_EXECUTABLE}" -c
-                "import pybind11; print(pybind11.get_cmake_dir())"
+            COMMAND "${PYTHON_EXECUTABLE}" -c
+                    "import pybind11; print(pybind11.get_cmake_dir())"
         OUTPUT_VARIABLE _tmp_dir
         OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ECHO STDOUT)
         list(APPEND CMAKE_PREFIX_PATH "${_tmp_dir}")

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Optional dependencies are the library ```pybind11``` and the Python module ```sc
 
 ## Installation
 
-In order to install the C++ libary run
+In order to install the C++ library run
 ```bash
 mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=/your/installation/path/ ..

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ Optional dependencies are the library ```pybind11``` and the Python module ```sc
 
 ## Installation
 
-In order to install both the C++ libary and the Python bindings run
+In order to install the C++ libary run
 ```bash
 mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=/your/installation/path/ ..
 make && make install
 ```
 
-In order to build just the Python bindings run
+In order to install the Python bindings run
 ```bash
 pip install .
 ```
@@ -43,7 +43,7 @@ For MacOS users: add the flags ```-std=c++17 -stdlib=libc++```.
 
 In order to use the Python module do
 ```bash
-import adanipy
+import adani
 ```
 remembering to run
 ```bash

--- a/bin/adani.pc.in
+++ b/bin/adani.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+includedir=@includedir@
+libdir=@libdir@
+
+Name: boh
+Description: The adani library
+Version: @VERSION@
+Cflags: -I@includedir@ -std=c++17
+Libs: -L@libdir@ -ladani

--- a/examples/test.py
+++ b/examples/test.py
@@ -1,4 +1,4 @@
-import adanipy
+import adani
 import numpy as np
 
 nf = 4
@@ -8,7 +8,7 @@ for x in np.geomspace(1e-4, 1, 5):
     for Q in np.geomspace(10, 100, 5):
         mQ = m**2 / Q**2
         mMu = mQ
-        print("C2_g^(3)(x=", x, ", Q=", Q, ") = ", adanipy.C2m_g3_approximation(x, mQ, mMu, nf))
-        print("C2_ps^(3)(x=", x, ", Q=", Q, ") = ", adanipy.C2m_ps3_approximation(x, mQ, mMu, nf))
-        print("CL_g^(3)(x=", x, ", Q=", Q, ") = ", adanipy.CLm_g3_approximation(x, mQ, mMu, nf))
-        print("CL_ps^(3)(x=", x, ", Q=", Q, ") = ", adanipy.CLm_ps3_approximation(x, mQ, mMu, nf))
+        print("C2_g^(3)(x=", x, ", Q=", Q, ") = ", adani.C2m_g3_approximation(x, mQ, mMu, nf))
+        print("C2_ps^(3)(x=", x, ", Q=", Q, ") = ", adani.C2m_ps3_approximation(x, mQ, mMu, nf))
+        print("CL_g^(3)(x=", x, ", Q=", Q, ") = ", adani.CLm_g3_approximation(x, mQ, mMu, nf))
+        print("CL_ps^(3)(x=", x, ", Q=", Q, ") = ", adani.CLm_ps3_approximation(x, mQ, mMu, nf))

--- a/inc/adani/__init__.py
+++ b/inc/adani/__init__.py
@@ -1,0 +1,1 @@
+from ._core import *

--- a/inc/adani/version.h.in
+++ b/inc/adani/version.h.in
@@ -1,1 +1,1 @@
-#define VERSION "@adani_VERSION@"
+#define VERSION "@PROJECT_VERSION@"

--- a/output/output_grid.py
+++ b/output/output_grid.py
@@ -1,4 +1,4 @@
-import adanipy
+import adani
 from multiprocessing import Pool
 import yaml
 import numpy as np
@@ -21,13 +21,13 @@ def function_to_exe_in_parallel(pair):
     mQ = m**2 / q**2
     mMu = m**2 / mu**2
     if runcard["channel"] == "2g":
-        return adanipy.C2m_g3_approximation(x, mQ, mMu, nf, 1, calls)
+        return adani.C2m_g3_approximation(x, mQ, mMu, nf, 1, calls)
     elif runcard["channel"] == "2q":
-        return adanipy.C2m_ps3_approximation(x, mQ, mMu, nf)
+        return adani.C2m_ps3_approximation(x, mQ, mMu, nf)
     elif runcard["channel"] == "Lg":
-        return adanipy.CLm_g3_approximation(x, mQ, mMu, nf, 1, calls)
+        return adani.CLm_g3_approximation(x, mQ, mMu, nf, 1, calls)
     elif runcard["channel"] == "Lq":
-        return adanipy.CLm_ps3_approximation(x, mQ, mMu, nf)
+        return adani.CLm_ps3_approximation(x, mQ, mMu, nf)
     else:
         raise ValueError("Set channel to one of these: 2g 2q Lg Lq")
 

--- a/pywrap/pywrap.cc
+++ b/pywrap/pywrap.cc
@@ -7,7 +7,7 @@
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(adanipy, m) {
+PYBIND11_MODULE(_core, m) {
     // Documentation
     m.doc() = "Python wrapper of libadani";
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-import sys
+import sys, os
 
 try:
     from skbuild import setup
@@ -9,7 +9,14 @@ except ImportError:
         file=sys.stderr,
     )
     raise
+
 from setuptools import find_packages
+
+# load long description from README
+this_directory = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
+    long_description = f.read()
+
 setup(
     name="adani",
     version="0.10", # el diez
@@ -18,6 +25,9 @@ setup(
     license="Fateci il cazzo che vi pare, basta che non mi rompete i coglioni",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
+    cmake_install_dir="src/adani",
     cmake_args=['-DPYTHON_ONLY:BOOL=ON'],
     python_requires=">=3.8",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
 )

--- a/src/ApproximateCoefficientFunctions.cc
+++ b/src/ApproximateCoefficientFunctions.cc
@@ -120,7 +120,7 @@ double C2m_g2_approximation_implicit(double x, double mQ, double mMu, double A, 
 
     double xmax = 1. / (1. + 4. * mQ) ;
 
-    if(x > xmax || x <= 0) return 0 ;
+    if(x >= xmax || x <= 0) return 0 ;
 
     double xi = 1. / mQ ;
 
@@ -216,7 +216,7 @@ double C2m_ps2_approximation_implicit(double x, double mQ, double mMu, double A,
 
     double xmax = 1. / (1. + 4. * mQ) ;
 
-    if(x > xmax || x <= 0) return 0 ;
+    if(x >= xmax || x <= 0) return 0 ;
 
     double xi = 1. / mQ ;
 
@@ -261,7 +261,7 @@ double CLm_g2_approximation_implicit(double x, double mQ, double mMu, double A, 
 
     double xmax = 1. / (1. + 4 * mQ) ;
 
-    if(x > xmax || x <= 0) return 0 ;
+    if(x >= xmax || x <= 0) return 0 ;
 
     double xi = 1. / mQ ;
 
@@ -308,7 +308,7 @@ double CLm_ps2_approximation_implicit(double x, double mQ, double mMu, double A,
 
     double xmax = 1. / (1. + 4. * mQ) ;
 
-    if(x > xmax || x <= 0) return 0 ;
+    if(x >= xmax || x <= 0) return 0 ;
 
     double xi = 1. / mQ ;
 
@@ -611,7 +611,7 @@ double C2m_g2_approximationA_klmv(double x, double mQ, double mMu) {
 
     double x_max=1/(1+4*mQ);
 
-    if(x>x_max || x<0) return 0;
+    if(x>=x_max || x<0) return 0;
 
     double beta=sqrt(1-4*mQ*x/(1-x));
 
@@ -655,7 +655,7 @@ double C2m_g2_approximationB_klmv(double x, double mQ, double mMu) {
 
     double x_max=1/(1+4*mQ);
 
-    if(x>x_max || x<0) return 0;
+    if(x>=x_max || x<0) return 0;
 
     double beta=sqrt(1-4*mQ*x/(1-x));
 
@@ -695,7 +695,7 @@ double C2m_ps2_approximationA_klmv(double x, double mQ, double mMu) {
 
     double x_max=1/(1+4*mQ);
 
-    if(x>x_max || x<0) return 0;
+    if(x>=x_max || x<0) return 0;
 
     double beta=sqrt(1-4*mQ*x/(1-x));
 
@@ -734,7 +734,7 @@ double C2m_ps2_approximationB_klmv(double x, double mQ, double mMu) {
 
     double x_max=1/(1+4*mQ);
 
-    if(x>x_max || x<0) return 0;
+    if(x>=x_max || x<0) return 0;
 
     double beta=sqrt(1-4*mQ*x/(1-x));
 
@@ -774,7 +774,7 @@ double C2m_g3_approximationA_klmv(double x, double mQ, double mMu, int nf) {
 
     double x_max=1/(1+4*mQ);
 
-    if(x>x_max || x<0) return 0;
+    if(x>=x_max || x<0) return 0;
     double pi2=M_PI*M_PI;
 
     double beta=sqrt(1-4*mQ*x/(1-x));
@@ -826,7 +826,7 @@ double C2m_g3_approximationB_klmv(double x, double mQ, double mMu, int nf) {
 
     double x_max=1/(1+4*mQ);
 
-    if(x>x_max || x<0) return 0;
+    if(x>=x_max || x<0) return 0;
 
     double pi2=M_PI*M_PI;
 
@@ -881,7 +881,7 @@ double C2m_g3_approximationB_klmv_paper(double x, double mQ, double mMu, int nf)
 
     double x_max=1/(1+4*mQ);
 
-    if(x>x_max || x<0) return 0;
+    if(x>=x_max || x<0) return 0;
 
     double pi2=M_PI*M_PI;
 
@@ -937,7 +937,7 @@ double C2m_g3_approximationBlowxi_klmv(double x, double mQ, double mMu, int nf) 
 
     double x_max=1/(1+4*mQ);
 
-    if(x>x_max || x<0) return 0;
+    if(x>=x_max || x<0) return 0;
 
     double pi2=M_PI*M_PI;
 
@@ -991,7 +991,7 @@ double C2m_ps3_approximationA_klmv(double x, double mQ, double mMu, int nf) {
 
     double x_max=1/(1+4*mQ);
 
-    if(x>x_max || x<0) return 0;
+    if(x>=x_max || x<0) return 0;
 
     double beta=sqrt(1-4*mQ*x/(1-x));
 
@@ -1036,7 +1036,7 @@ double C2m_ps3_approximationB_klmv(double x, double mQ, double mMu, int nf) {
 
     double x_max=1/(1+4*mQ);
 
-    if(x>x_max || x<0) return 0;
+    if(x>=x_max || x<0) return 0;
 
     double beta=sqrt(1-4*mQ*x/(1-x));
 
@@ -1084,7 +1084,7 @@ double C2m_ps3_approximationA_klmv_paper(double x, double mQ, double mMu, int nf
 
     double x_max=1/(1+4*mQ);
 
-    if(x>x_max || x<0) return 0;
+    if(x>=x_max || x<0) return 0;
 
     double beta=sqrt(1-4*mQ*x/(1-x));
 
@@ -1131,7 +1131,7 @@ double C2m_ps3_approximationB_klmv_paper(double x, double mQ, double mMu, int nf
 
     double x_max=1/(1+4*mQ);
 
-    if(x>x_max || x<0) return 0;
+    if(x>=x_max || x<0) return 0;
 
     double beta=sqrt(1-4*mQ*x/(1-x));
 

--- a/src/Convolutions.cc
+++ b/src/Convolutions.cc
@@ -343,7 +343,7 @@ double Pgg0sing_integrand(double z, void * p) {
 double C2m_g1_x_Pgg0(double x, double mQ, int nf) {
 
     double x_max=1./(1+4*mQ);
-    if (x>x_max || x<0) return 0. ;
+    if (x>=x_max || x<0) return 0. ;
 
     gsl_integration_workspace * w = gsl_integration_workspace_alloc (1000);
 
@@ -414,7 +414,7 @@ double CLm_g1_x_Pgg0_sing_integrand(double z, void * p) {
 double CLm_g1_x_Pgg0(double x, double mQ, int nf) {
 
     double x_max=1./(1+4*mQ);
-    if (x>x_max || x<0) return 0. ;
+    if (x>=x_max || x<0) return 0. ;
 
     gsl_integration_workspace * w = gsl_integration_workspace_alloc (1000);
 

--- a/src/MassiveCoefficientFunctions.cc
+++ b/src/MassiveCoefficientFunctions.cc
@@ -18,7 +18,7 @@ double C2m_g1(double x, double mQ) { //mQ=m^2/Q^2
 
     double x_max = 1. / (1. + 4. * mQ) ;
 
-    if (x>x_max || x<0) return 0;
+    if (x>=x_max || x<0) return 0;
 
     double beta = sqrt(1. - 4. * mQ * x / (1 - x)) ;
     double x2 = x * x ;
@@ -42,7 +42,7 @@ double CLm_g1(double x, double mQ) {
 
     double x_max = 1. / (1. + 4. * mQ) ;
 
-    if (x>x_max || x<0) return 0;
+    if (x>=x_max || x<0) return 0;
 
     double beta = sqrt(1. - 4. * mQ * x / (1. - x)) ;
     double x2 = x * x ;
@@ -97,7 +97,7 @@ double C2m_g2(double x, double mQ, double mMu) {
 
     double x_max = 1. / (1 + 4 * mQ) ;
 
-    if (x>x_max || x<0) return 0;
+    if (x>=x_max || x<0) return 0;
 
     //if(eta > 1e6 || eta < 1e-6 || xi<1e-3 || xi>1e5) return __builtin_nan("");
     if(eta > 1e6 || eta < 1e-6 || xi<1e-3 || xi>1e5) return 0.;
@@ -123,7 +123,7 @@ double C2m_ps2(double x, double mQ, double mMu) {
 
     double x_max = 1. / (1 + 4 * mQ) ;
 
-    if (x>x_max || x<0) return 0;
+    if (x>=x_max || x<0) return 0;
 
     //if(eta > 1e6 || eta < 1e-6 || xi<1e-3 || xi>1e5) return __builtin_nan("");
     if(eta > 1e6 || eta < 1e-6 || xi<1e-3 || xi>1e5) return 0.;
@@ -149,7 +149,7 @@ double CLm_g2(double x, double mQ, double mMu) {
 
     double x_max = 1. / (1 + 4 * mQ) ;
 
-    if (x>x_max || x<0) return 0;
+    if (x>=x_max || x<0) return 0;
 
     //if(eta > 1e6 || eta < 1e-6 || xi<1e-3 || xi>1e5) return __builtin_nan("");
     if(eta > 1e6 || eta < 1e-6 || xi<1e-3 || xi>1e5) return 0.;
@@ -175,7 +175,7 @@ double CLm_ps2(double x, double mQ, double mMu) {
 
     double x_max = 1. / (1 + 4 * mQ) ;
 
-    if (x>x_max || x<0) return 0;
+    if (x>=x_max || x<0) return 0;
 
     //if(eta > 1e6 || eta < 1e-6 || xi<1e-3 || xi>1e5) return __builtin_nan("");
     if(eta > 1e6 || eta < 1e-6 || xi<1e-3 || xi>1e5) return 0.;
@@ -237,7 +237,7 @@ double C2m_ps21(double x, double mQ) {
 
     double x_max = 1. / (1. + 4. * mQ) ;
 
-    if (x>x_max || x<0) return 0;
+    if (x>=x_max || x<0) return 0;
 
     return - C2m_g1_x_Pgq0(x, mQ);
     // The minus sign comes from the fact that in [arXiv:1205.5727]
@@ -258,7 +258,7 @@ double CLm_ps21(double x, double mQ) {
 
     double x_max = 1. / (1. + 4. * mQ) ;
 
-    if (x>x_max || x<0) return 0;
+    if (x>=x_max || x<0) return 0;
 
     return - CLm_g1_x_Pgq0(x, mQ);
 
@@ -275,7 +275,7 @@ double C2m_g21(double x, double mQ) {
 
     double x_max = 1. / (1. + 4. * mQ) ;
 
-    if (x>x_max || x<0) return 0;
+    if (x>=x_max || x<0) return 0;
 
     int nf = 1 ;
     //Put nf to 1 since the nf contribution cancels for any value of nf
@@ -295,7 +295,7 @@ double CLm_g21(double x, double mQ) {
 
     double x_max = 1. / (1. + 4. * mQ) ;
 
-    if (x>x_max || x<0) return 0;
+    if (x>=x_max || x<0) return 0;
 
     int nf = 1 ;
     //Put nf to 1 since the nf contribution cancels for any value of nf
@@ -315,7 +315,7 @@ double C2m_ps31(double x, double mQ, int nf) {
 
     double x_max = 1. / (1. + 4. * mQ) ;
 
-    if (x>x_max || x<0) return 0;
+    if (x>=x_max || x<0) return 0;
 
     return - (
         C2m_g1_x_Pgq1(x, mQ, nf)
@@ -337,7 +337,7 @@ double CLm_ps31(double x, double mQ, int nf) {
 
     double x_max = 1. / (1. + 4. * mQ) ;
 
-    if (x>x_max || x<0) return 0;
+    if (x>=x_max || x<0) return 0;
 
     return - (
         CLm_g1_x_Pgq1(x, mQ, nf)
@@ -359,7 +359,7 @@ double C2m_ps32(double x, double mQ, int nf) {
 
     double x_max = 1. / (1. + 4. * mQ) ;
 
-    if (x>x_max || x<0) return 0;
+    if (x>=x_max || x<0) return 0;
 
     return (
         0.5 * (C2m_g1_x_Pgg0_x_Pgq0(x, mQ, nf) + C2m_g1_x_Pqq0_x_Pgq0(x, mQ, nf))
@@ -379,7 +379,7 @@ double CLm_ps32(double x, double mQ, int nf) {
 
     double x_max = 1. / (1. + 4. * mQ) ;
 
-    if (x>x_max || x<0) return 0;
+    if (x>=x_max || x<0) return 0;
 
     return (
         0.5 * (CLm_g1_x_Pgg0_x_Pgq0(x, mQ, nf) + CLm_g1_x_Pqq0_x_Pgq0(x, mQ, nf))
@@ -399,7 +399,7 @@ double C2m_g31(double x, double mQ, int nf) {
 
     double x_max = 1. / (1. + 4. * mQ) ;
 
-    if (x>x_max || x<0) return 0. ;
+    if (x>=x_max || x<0) return 0. ;
 
     return -(
         C2m_g1_x_Pgg1(x, mQ, nf)
@@ -422,7 +422,7 @@ double CLm_g31(double x, double mQ, int nf) {
 
     double x_max = 1. / (1. + 4. * mQ) ;
 
-    if (x>x_max || x<0) return 0. ;
+    if (x>=x_max || x<0) return 0. ;
 
     return -(
         CLm_g1_x_Pgg1(x, mQ, nf)
@@ -445,7 +445,7 @@ double C2m_g32(double x, double mQ, int nf, int method_flag, int calls) {
 
     double x_max = 1. / (1. + 4. * mQ) ;
 
-    if (x>x_max || x<0) return 0;
+    if (x>=x_max || x<0) return 0;
 
     double C2m_g1xPgg0xPgg0 ;
 
@@ -476,7 +476,7 @@ double CLm_g32(double x, double mQ, int nf, int method_flag, int calls) {
 
     double x_max = 1. / (1. + 4. * mQ) ;
 
-    if (x>x_max || x<0) return 0;
+    if (x>=x_max || x<0) return 0;
 
     double CLm_g1xPgg0xPgg0 ;
 

--- a/src/SplittingFunctions.cc
+++ b/src/SplittingFunctions.cc
@@ -13,7 +13,7 @@ using namespace std;
 
 double pgq(double x){
 
-    if (x<0 || x>1) return 0;
+    if (x<0 || x>=1) return 0;
 
     return 2. / x - 2. + x ;
 }
@@ -26,7 +26,7 @@ double pgq(double x){
 
 double pqg(double x) {
 
-    if (x<0 || x>1) return 0.;
+    if (x<0 || x>=1) return 0.;
 
     return 1. - 2. * x + 2. * x * x ;
 
@@ -40,7 +40,7 @@ double pqg(double x) {
 
 double pggreg(double x) {
 
-    if (x<0 || x>1) return 0.;
+    if (x<0 || x>=1) return 0.;
 
     return 1. / x - 2. + x - x * x ;
 
@@ -131,7 +131,7 @@ double Pgg0sing (double x) {
 
 double Pqq0reg(double x) {
 
-    if (x<0 || x>1) return 0. ;
+    if (x<0 || x>=1) return 0. ;
 
     return CF * 2. * (- 1 - x) / 4 / M_PI ;
 
@@ -169,7 +169,7 @@ double Pqq0sing(double x) {
 
 double Pgq1(double x, int nf) {
 
-    if (x<0 || x>1) return 0. ;
+    if (x<0 || x>=1) return 0. ;
 
     double H0 = H(x, 0) ;
     double H1 = H(x, 1) ;
@@ -230,7 +230,7 @@ double Pgq1(double x, int nf) {
 
 double Pgg1reg(double x, int nf) {
 
-    if (x<0 || x>1) return 0. ;
+    if (x<0 || x>=1) return 0. ;
 
     double H0 = H(x, 0) ;
 

--- a/src/ThresholdCoefficientFunctions.cc
+++ b/src/ThresholdCoefficientFunctions.cc
@@ -18,7 +18,7 @@ double C2m_g1_threshold(double x, double mQ) {
 
     double xmax = 1. / (1. + 4 * mQ) ;
 
-    if (x>xmax || x<0) return 0;
+    if (x>=xmax || x<0) return 0;
 
     double beta = sqrt(1. - 4. * mQ * x / (1. - x)) ;
     double xi = 1. / mQ ;
@@ -38,7 +38,7 @@ double C2m_g2_threshold(double x, double mQ, double mMu) {
 
     double xmax = 1. / (1. + 4 * mQ) ;
 
-    if(x>xmax || x<0) return 0;
+    if(x>=xmax || x<0) return 0;
 
     double beta = sqrt(1. - 4 * mQ * x / (1. - x));
     double xi = 1. / mQ;
@@ -74,7 +74,7 @@ double CLm_g2_threshold(double x, double mQ, double mMu) {
 
     double xmax = 1. / (1. + 4 * mQ) ;
 
-    if(x>xmax || x<0) return 0;
+    if(x>=xmax || x<0) return 0;
 
     double beta = sqrt(1. - 4 * mQ * x / (1. - x));
     double xi = 1. / mQ ;
@@ -109,7 +109,7 @@ double C2m_g3_threshold(double x, double mQ, double mMu, int nf) {
 
     double x_max = 1. / (1. + 4 * mQ);
 
-    if(x>x_max || x<0) return 0;
+    if(x>=x_max || x<0) return 0;
 
     double xi = 1. / mQ ;
     double beta = sqrt(1. - 4. * mQ * x / (1. - x));
@@ -190,7 +190,7 @@ double CLm_g3_threshold(double x, double mQ, double mMu, int nf) {
 
     double x_max=1./(1+4*mQ);
 
-    if(x>x_max || x<0) return 0;
+    if(x>=x_max || x<0) return 0;
 
     double xi=1/mQ;
     double beta=sqrt(1-4*mQ*x/(1-x));


### PR DESCRIPTION
Pull request made for fixing the following problems:
- Python module (`adanipy`) had a different name w.r.t. C++ library (`adani`)
- The python-only installation could be performed only if the C++ installation had been already performed
- Now the python package is mode package-like