### PR TITLE
Remove 4pi from almost all functions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/inc/adani/Constants.h
+++ b/inc/adani/Constants.h
@@ -24,7 +24,7 @@ const double zeta3 = 1.2020569031595942 ;
 const double zeta4 = 1.0823232337111381 ;
 const double zeta5 = 1.03692775514337 ;
 
-const double pi2 = 9.869604401089358 ;
-const double pi3 = 31.006276680299816 ;
+// const double pi2 = 9.869604401089358 ;
+// const double pi3 = 31.006276680299816 ;
 
 #endif

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,9 @@ with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
 setup(
     name="adani",
     version="0.10", # el diez
-    description="Un codice scritto a cazzo di cane",
+    description="Code computing approximate DIS N3LO coefficients",
     author="Niccolò Laurenti",
-    license="Fateci il cazzo che vi pare, basta che non mi rompete i coglioni",
+    license="AGPLv3",
     packages=find_packages(where="inc"),
     package_dir={"": "inc"},
     cmake_install_dir="inc/adani",

--- a/src/ApproximateCoefficientFunctions.cc
+++ b/src/ApproximateCoefficientFunctions.cc
@@ -751,6 +751,8 @@ double C2_g3_approximationA_klmv(double x, double mQ, double mMu, int nf, int me
 
     if(x>=x_max || x<0) return 0;
 
+    double pi3 = M_PI * M_PI * M_PI ;
+
     double beta = sqrt(1. - 4 * mQ * x / (1. - x));
 
     double eta = 0.25 / mQ * (1. - x) / x - 1. ;
@@ -765,7 +767,7 @@ double C2_g3_approximationA_klmv(double x, double mQ, double mMu, int nf, int me
 
     double beta3 = beta * beta * beta;
 
-    double C2_g3_highenergyA = (
+    double C2_g3_highenergyA = (64. * pi3) * (
         0.007 * pow(log(1./mQ) / log(5), 4) - 0.28
     ) * 4. / mQ / x;
 
@@ -802,6 +804,8 @@ double C2_g3_approximationB_klmv(double x, double mQ, double mMu, int nf, int me
 
     if(x>=x_max || x<0) return 0;
 
+    double pi3 = M_PI * M_PI * M_PI ;
+
     double beta = sqrt(1. - 4 * mQ * x / (1. - x));
 
     double eta = 0.25 / mQ * (1. - x) / x - 1.;
@@ -816,7 +820,7 @@ double C2_g3_approximationB_klmv(double x, double mQ, double mMu, int nf, int me
 
     double beta3 = beta * beta * beta;
 
-    double C2_g3_highenergyB = (
+    double C2_g3_highenergyB = (64. * pi3) * (
         0.055 * pow(log(1./mQ) / log(5), 2) - 0.423
     ) * 4. / mQ / x;
 
@@ -855,6 +859,8 @@ double C2_g3_approximationB_klmv_paper(double x, double mQ, double mMu, int nf, 
 
     if(x>=x_max || x<0) return 0;
 
+    double pi3 = M_PI * M_PI * M_PI ;
+
     double beta = sqrt(1. - 4 * mQ * x / (1. - x));
 
     double eta = 0.25 / mQ * (1. - x) / x - 1;
@@ -869,7 +875,7 @@ double C2_g3_approximationB_klmv_paper(double x, double mQ, double mMu, int nf, 
 
     double beta3 = beta * beta * beta;
 
-    double C2_g3_highenergyB = (
+    double C2_g3_highenergyB = (64. * pi3) * (
         0.055 * pow(log(1./mQ) / log(5), 2) - 0.423
     ) * 4. / mQ / x;
 
@@ -910,6 +916,8 @@ double C2_g3_approximationBlowxi_klmv(double x, double mQ, double mMu, int nf, i
 
     if(x>=x_max || x<0) return 0;
 
+    double pi3 = M_PI * M_PI * M_PI ;
+
     double beta = sqrt(1. - 4 * mQ * x / (1. - x));
 
     double eta = 0.25 / mQ * (1. - x) / x - 1.;
@@ -924,7 +932,7 @@ double C2_g3_approximationBlowxi_klmv(double x, double mQ, double mMu, int nf, i
 
     double beta3 = beta * beta * beta;
 
-    double C2_g3_highenergyB= CA / CF * (
+    double C2_g3_highenergyB = CA / CF * (64. * pi3) * (
         0.0245 * pow(log(1./mQ) / log(5), 2) - 0.17
     ) * 4. / mQ / x;
 
@@ -963,6 +971,8 @@ double C2_ps3_approximationA_klmv(double x, double mQ, double mMu, int nf) {
 
     if(x>=x_max || x<0) return 0;
 
+    double pi3 = M_PI * M_PI * M_PI ;
+
     double beta = sqrt(1. - 4. * mQ * x / (1. - x));
 
     double eta = 0.25 / mQ * (1. - x) / x - 1.;
@@ -977,7 +987,7 @@ double C2_ps3_approximationA_klmv(double x, double mQ, double mMu, int nf) {
 
     double beta3 = beta * beta * beta;
 
-    double C2_ps30_highenergyNLLA = (
+    double C2_ps30_highenergyNLLA = (64. * pi3) *(
         0.004 * pow(log(1./mQ) / log(5), 4) - 0.125
     ) * 4. / mQ / x;
 
@@ -1013,6 +1023,8 @@ double C2_ps3_approximationB_klmv(double x, double mQ, double mMu, int nf) {
 
     if(x>=x_max || x<0) return 0;
 
+    double pi3 = M_PI * M_PI * M_PI ;
+
     double beta = sqrt(1. - 4. * mQ * x / (1. - x));
 
     double eta = 0.25 / mQ * (1. - x) / x - 1.;
@@ -1027,7 +1039,7 @@ double C2_ps3_approximationB_klmv(double x, double mQ, double mMu, int nf) {
 
     double beta3 = beta * beta * beta;
 
-    double C2_ps30_highenergyNLLB = (
+    double C2_ps30_highenergyNLLB = (64. * pi3) * (
         0.0245 * pow(log(1./mQ) / log(5), 2) - 0.17
     ) * 4. / mQ / x;
 
@@ -1066,6 +1078,8 @@ double C2_ps3_approximationA_klmv_paper(double x, double mQ, double mMu, int nf)
 
     if(x>=x_max || x<0) return 0;
 
+    double pi3 = M_PI * M_PI * M_PI ;
+
     double beta = sqrt(1. - 4. * mQ * x / (1. - x));
 
     double eta = 0.25 / mQ * (1. - x) / x - 1.;
@@ -1080,7 +1094,7 @@ double C2_ps3_approximationA_klmv_paper(double x, double mQ, double mMu, int nf)
 
     double beta3 = beta * beta * beta;
 
-    double C2_ps30_highenergyNLLA = (
+    double C2_ps30_highenergyNLLA = (64. * pi3) *(
         0.004 * pow(log(1./mQ) / log(5), 4) - 0.125
     ) * 4. / mQ / x;
 
@@ -1118,6 +1132,8 @@ double C2_ps3_approximationB_klmv_paper(double x, double mQ, double mMu, int nf)
 
     if(x>=x_max || x<0) return 0;
 
+    double pi3 = M_PI * M_PI * M_PI ;
+
     double beta = sqrt(1. - 4. * mQ * x / (1. - x));
 
     double eta = 0.25 / mQ * (1. - x) / x - 1.;
@@ -1132,7 +1148,7 @@ double C2_ps3_approximationB_klmv_paper(double x, double mQ, double mMu, int nf)
 
     double beta3 = beta * beta * beta;
 
-    double C2_ps30_highenergyNLLB = (
+    double C2_ps30_highenergyNLLB = (64. * pi3) * (
         0.0245 * pow(log(1./mQ) / log(5), 2) - 0.17
     ) * 4 / mQ / x;
 

--- a/src/Convolutions.cc
+++ b/src/Convolutions.cc
@@ -25,15 +25,14 @@ double C2_b1_x_K_Qg1(double x, double mMu) {
     double x1 = 1 - x ;
     double L = log(x) ;
     double L1 = log(x1) ;
-    double pi2 = M_PI * M_PI ;
 
     double res = (
-        -5. / 2. +  2. * (3. - 4. * x) * x + pi2 / 6. * (-1. + 2. * x - 4. * x2)
+        -5. / 2. +  2. * (3. - 4. * x) * x + zeta2 * (-1. + 2. * x - 4. * x2)
         + L1 * L1 * (1. - 2. * x1 * x) - 0.5 * L1 * (7. + 4. * x * (-4. + 3. * x) + (4. - 8. * x1 * x) * L)
         + 0.5 * L * (-1. + 4. * x * (3. * x - 2.) + (1. - 2. * x + 4. * x2) * L) + (2. * x - 1.) * Li2(x)
     ) ;
 
-    return 4. * CF * TR * res * log(1./mMu) / 16. / pi2 ;
+    return 4. * CF * TR * res * log(1./mMu) ;
 
 }
 
@@ -48,9 +47,8 @@ double CL_b1_x_K_Qg1(double x, double mMu) {
 
     double x2 = x * x ;
     double L = log(x) ;
-    double pi2 = M_PI * M_PI ;
 
-    return 8. * CF * TR * (1. + x - 2. * x2 + 2. * x * L) * log(1./mMu) / 16. / pi2 ;
+    return 8. * CF * TR * (1. + x - 2. * x2 + 2. * x * L) * log(1./mMu) ;
 
 }
 
@@ -754,7 +752,7 @@ double CL_ps20_x_Pqq0(double x, double mQ, int nf) {
 
 double Pgg0_x_Pgq0(double x, int nf) {
 
-    double tmp = (
+    return (
         - 4. * CF * nf * (2. + (- 2. + x) * x)
         + 2. * CA * CF * (
             - 40. + x * (26. + x * (17. + 8. * x))
@@ -762,8 +760,6 @@ double Pgg0_x_Pgq0(double x, int nf) {
             - 24. * (1. + x + x * x) * log(x)
         )
     ) / 3. / x ;
-
-    return tmp / (16. * M_PI * M_PI) ;
 
 }
 
@@ -773,14 +769,12 @@ double Pgg0_x_Pgq0(double x, int nf) {
 
 double Pqq0_x_Pgq0(double x) {
 
-    double tmp = (
+    return (
         2. * CF * CF * (
             4. * (2. + (- 2. + x) * x) * log(1. - x)
             - x * (- 4. + x + 2. * (- 2. + x) * log(x))
         )
     ) / x ;
-
-    return tmp / (16 * M_PI * M_PI) ;
 
 }
 
@@ -1324,11 +1318,9 @@ double CL_g20_x_Pgg0(double x, double mQ, int nf) {
 
 double Pqg0_x_Pgq0(double x, int nf) {
 
-    double tmp = 4. * CF * nf * (
+    return 4. * CF * nf * (
         1. + 4. / 3 / x - x - 4. * x * x / 3 + 2. * (1 + x) * log(x)
     ) ;
-
-    return tmp / (16. * M_PI * M_PI) ;
 
 }
 

--- a/src/Convolutions.cc
+++ b/src/Convolutions.cc
@@ -1059,7 +1059,7 @@ double CL_g1_x_Pgg1_sing_integrand(double z, void * p) {
     double x = (params->x);
     int nf = (params->nf);
 
-    return Pgg1sing(z, nf) * (CL_g1(x / z, mQ) / z - CL_g1(x , mQ)) ;
+    return Pgg1sing(z, nf) * (CL_g1(x / z, mQ) / z - CL_g1(x, mQ)) ;
 
 }
 
@@ -1443,7 +1443,7 @@ double C2_g1_x_Pgg0_x_Pgg0_sing_integrand(double z, void * p) {
     double x = (params->x);
     int nf = (params->nf);
 
-    return Pgg0sing(z) * (C2_g1_x_Pgg0(x / z, mQ, nf) / z - C2_g1_x_Pgg0(x , mQ, nf)) ;
+    return Pgg0sing(z) * (C2_g1_x_Pgg0(x / z, mQ, nf) / z - C2_g1_x_Pgg0(x, mQ, nf)) ;
 
 }
 
@@ -1972,7 +1972,9 @@ double CL_g1_x_Pgg0_x_Pgg0_sing1_integrand(double z[], size_t dim, void * p) {
 
     double z1 = z[0], z2 = z[1] ;
 
-    return 1. / z2 * theta(z1 - x) * Pgg0sing(z1) * (theta(z2 - x / z1) / z1 * Pgg0reg(x / (z1 * z2)) - theta(z2 - x) * Pgg0reg(x / z2)) * CL_g1(z2, mQ) ;
+    return 1. / z2 * theta(z1 - x) * Pgg0sing(z1) * (
+            theta(z2 - x / z1) / z1 * Pgg0reg(x / (z1 * z2)) - theta(z2 - x) * Pgg0reg(x / z2)
+        ) * CL_g1(z2, mQ) ;
 
 }
 
@@ -1993,7 +1995,10 @@ double CL_g1_x_Pgg0_x_Pgg0_sing2_integrand(double z[], size_t dim, void * p) {
 
     double z1 = z[0], z2 = z[1] ;
 
-    return theta(z1 - x) * Pgg0sing(z1) * (Pgg0sing(z2) / z1 * (CL_g1(x / (z1 * z2), mQ) / z2 - CL_g1(x / z1, mQ)) * theta(z2 - x / z1) - Pgg0sing(z2) * (CL_g1(x / z2, mQ) / z2 - CL_g1(x, mQ)) * theta(z2 - x)) ;
+    return theta(z1 - x) * Pgg0sing(z1) * (
+        Pgg0sing(z2) / z1 * (CL_g1(x / (z1 * z2), mQ) / z2 - CL_g1(x / z1, mQ)) * theta(z2 - x / z1)
+        - Pgg0sing(z2) * (CL_g1(x / z2, mQ) / z2 - CL_g1(x, mQ)) * theta(z2 - x)
+    ) ;
 
 }
 

--- a/src/ExactCoefficientFunctions.cc
+++ b/src/ExactCoefficientFunctions.cc
@@ -459,7 +459,7 @@ double C2_g31(double x, double mQ, int nf) {
         - beta(1, nf) * C2_g1(x, mQ)
         + C2_ps20_x_Pqg0(x, mQ, nf)
         + C2_g20_x_Pgg0(x, mQ, nf)
-        - 2. * beta(0,nf) * C2_g20(x, mQ)
+        - 2. * beta(0, nf) * C2_g20(x, mQ)
    );
 
 }
@@ -482,7 +482,7 @@ double CL_g31(double x, double mQ, int nf) {
         - beta(1, nf) * CL_g1(x, mQ)
         + CL_ps20_x_Pqg0(x, mQ, nf)
         + CL_g20_x_Pgg0(x, mQ, nf)
-        - 2 * beta(0,nf) * CL_g20(x, mQ)
+        - 2 * beta(0, nf) * CL_g20(x, mQ)
    );
 
 }

--- a/src/ExactCoefficientFunctions.cc
+++ b/src/ExactCoefficientFunctions.cc
@@ -28,7 +28,7 @@ double C2_g1(double x, double mQ) { //mQ=m^2/Q^2
     return 4 * TR * (
         L * (-8 * x2 * mQ2 - 4 * x * mQ * (3 * x - 1) + 2 * x2 - 2 * x + 1)
         + beta * (4 * mQ * x * (x - 1) - (8 * x2 - 8 * x + 1))
-    ) / 4. / M_PI ;
+    ) ;
 
 }
 
@@ -50,7 +50,7 @@ double CL_g1(double x, double mQ) {
 
     return 16. * TR * (
         x * (1. - x) * beta - 2. * x2 * mQ * L
-    ) / 4. / M_PI ;
+    ) ;
 
 }
 
@@ -217,7 +217,7 @@ double C2_ps20(double x, double mQ) {
     //if(eta > 1e6 || eta < 1e-6 || xi<1e-3 || xi>1e5) return __builtin_nan("");
     if(eta > 1e6 || eta < 1e-6 || xi<1e-3 || xi>1e5) return 0.;
 
-    return xi * c2nloq_(&eta, &xi) / x / M_PI ;
+    return 16 * M_PI * xi * c2nloq_(&eta, &xi) / x ;
 
 }
 
@@ -257,7 +257,7 @@ double CL_ps20(double x, double mQ) {
     //if(eta > 1e6 || eta < 1e-6 || xi<1e-3 || xi>1e5) return __builtin_nan("");
     if(eta > 1e6 || eta < 1e-6 || xi<1e-3 || xi>1e5) return 0.;
 
-    return xi * clnloq_(&eta, &xi) / x / M_PI ;
+    return 16 * M_PI * xi * clnloq_(&eta, &xi) / x ;
 
 }
 
@@ -293,7 +293,7 @@ double C2_g20(double x, double mQ) {
     //if(eta > 1e6 || eta < 1e-6 || xi<1e-3 || xi>1e5) return __builtin_nan("");
     if(eta > 1e6 || eta < 1e-6 || xi<1e-3 || xi>1e5) return 0.;
 
-    return xi * c2nlog_(&eta, &xi) / x / M_PI ;
+    return 16 * M_PI * xi * c2nlog_(&eta, &xi) / x ;
 
 }
 
@@ -333,7 +333,7 @@ double CL_g20(double x, double mQ) {
     //if(eta > 1e6 || eta < 1e-6 || xi<1e-3 || xi>1e5) return __builtin_nan("");
     if(eta > 1e6 || eta < 1e-6 || xi<1e-3 || xi>1e5) return 0.;
 
-    return xi * clnlog_(&eta, &xi) / x / M_PI ;
+    return 16 * M_PI * xi * clnlog_(&eta, &xi) / x ;
 
 }
 

--- a/src/HighEnergyCoefficientFunctions.cc
+++ b/src/HighEnergyCoefficientFunctions.cc
@@ -17,8 +17,6 @@ double C2_g2_highenergy(double x, double mQ, double mMu) {
 
     if(x>=1 || x<0) return 0;
 
-    double pi2 = M_PI * M_PI;
-
     double z = sqrt(1. / (1. + 4. * mQ));
 
     double L = log((1. + z) / (1. - z));
@@ -34,7 +32,7 @@ double C2_g2_highenergy(double x, double mQ, double mMu) {
 
     double c_LMu = 2. + (1. - mQ) * J ;
 
-    return  CA / 12. / pi2 * (c_const + c_LMu * LMu) / x ;
+    return  4. / 3. * CA * (c_const + c_LMu * LMu) / x ;
 
 }
 
@@ -73,14 +71,14 @@ double CL_g2_highenergy(double x, double mQ, double mMu) {
         4. * (-1. + 12. * mQ) / (3. + 12. * mQ)
         + (5. - 12. * mQ + 1. / (1. + 4. * mQ)) * J / 6.
         - 4. * mQ * (1. + 3. * mQ) / (1. + 4. * mQ) * I
-    ) / 6. ;
+    ) / 3. ;
 
     double c_LMu = (
         - 4. * (1. + 6. * mQ) / (1. + 4. * mQ)
         + 4. * mQ * (1. + 3. * mQ) / (1. + 4. * mQ) * J
-    ) / 6. ;
+    ) / 3. ;
 
-    return CA * TR * (c_const + c_LMu * LMu) / pi2 / x ;
+    return 8 * CA * TR * (c_const + c_LMu * LMu) / x ;
 
 }
 
@@ -105,8 +103,6 @@ double C2_g2_highenergy_highscale(double x, double mQ , double mMu) {
 
     if(x>=1 || x<0) return 0;
 
-    double pi2 = M_PI * M_PI;
-
     double LQ = log(1. / mQ);
     double L2Q = LQ * LQ;
 
@@ -115,7 +111,7 @@ double C2_g2_highenergy_highscale(double x, double mQ , double mMu) {
     return CA * (
         8. / 3. * L2Q + 104. / 9. * LQ + 40. / 9. - 16. / 3. * zeta2
         + (16. / 3. * LQ + 8. / 3.) * Lm
-    ) / x / (16 * pi2) ;
+    ) / x ;
 
 }
 
@@ -140,8 +136,6 @@ double CL_g2_highenergy_highscale(double x, double mQ , double mMu) {
 
     if(x>=1 || x<0) return 0;
 
-    double pi2 = M_PI * M_PI;
-
     double LQ = log(1./mQ);
 
     double Lm = log(1./mMu);
@@ -150,7 +144,7 @@ double CL_g2_highenergy_highscale(double x, double mQ , double mMu) {
 
     double c_log = - 2. / 3.;
 
-    return CA * TR / (pi2) / x * (c_const + c_log * Lm);
+    return 16 * CA * TR / x * (c_const + c_log * Lm);
 
 }
 
@@ -224,9 +218,6 @@ double C2_g3_highenergyLL(double x, double mQ, double mMu) {
 
     if(x>=1 || x<0) return 0;
 
-    double pi2 = M_PI * M_PI;
-    double pi3 = M_PI * pi2;
-
     double z = sqrt(1. / (1. + 4. * mQ));
 
     double L = log((1. + z) / (1. - z));
@@ -254,7 +245,7 @@ double C2_g3_highenergyLL(double x, double mQ, double mMu) {
 
     double c_L2Mu = -2./3. - 1./3. * (1. - mQ) * J;
 
-    return 4 * CA * CA * log(x) / (32 * pi3) * (c_const + c_LMu * LMu + c_L2Mu * L2Mu) / x;
+    return 8. * CA * CA * log(x) * (c_const + c_LMu * LMu + c_L2Mu * L2Mu) / x;
 
 }
 
@@ -267,8 +258,6 @@ double C2_g3_highenergyLL(double x, double mQ, double mMu) {
 double C2_g3_highenergy(double x, double mQ, double mMu, int nf) {
 
     if(x>=1 || x<0) return 0;
-
-    double pi2 = M_PI*M_PI ;
 
     double z = sqrt(1. / (1. + 4. * mQ));
 
@@ -285,9 +274,9 @@ double C2_g3_highenergy(double x, double mQ, double mMu, int nf) {
     double J = 4 * z * L;
     double K = 4 * z * Hmpm;
 
-    double a11 = CA / M_PI;
-    double a21 = nf * (26. * CF - 23. * CA) / 36 / pi2;
-    double a10 = - (11. * CA + 2. * nf * (1. - 2. * CF / CA)) / 12. / M_PI;
+    double a11 = CA ;
+    double a21 = nf * (26. * CF - 23. * CA) / 36 ;
+    double a10 = - (11. * CA + 2. * nf * (1. - 2. * CF / CA)) / 12. ;
 
     double beta0 = beta(0, nf) ;
 
@@ -341,7 +330,7 @@ double C2_g3_highenergy(double x, double mQ, double mMu, int nf) {
         )
     ) ;
 
-    return tmp / (12 * M_PI * x) ;
+    return 16. / 3 * tmp / x ;
 
 }
 
@@ -372,8 +361,6 @@ double CL_g3_highenergy(double x, double mQ, double mMu, int nf) {
 
     if(x>=1 || x<0) return 0;
 
-    double pi2 = M_PI * M_PI ;
-
     double xi = 1./mQ;
 
     double z = sqrt(1. / (1. + 4. * mQ));
@@ -391,9 +378,9 @@ double CL_g3_highenergy(double x, double mQ, double mMu, int nf) {
     double J = 4 * mQ * z * log(sqrt(xi) / 2 + sqrt(xi/4 + 1.)); // = 4 * mQ * z * acsch(2. / sqrt(xi))
     double K = 4 * mQ * z * Hmpm;
 
-    double a11 = CA / M_PI;
-    double a21 = nf * (26 * CF - 23 * CA) / 36 / pi2;
-    double a10 = -(11 * CA + 2 * nf * (1 - 2 * CF / CA)) / 12 / M_PI ;
+    double a11 = CA ;
+    double a21 = nf * (26 * CF - 23 * CA) / 36 ;
+    double a10 = -(11 * CA + 2 * nf * (1 - 2 * CF / CA)) / 12 ;
 
     double beta0 = beta(0, nf) ;
 
@@ -449,7 +436,7 @@ double CL_g3_highenergy(double x, double mQ, double mMu, int nf) {
         )
     ) ;
 
-    return tmp/(12 * M_PI * mQ * (4 + xi) * x) ;
+    return 16. / 3 * tmp / (mQ * (4 + xi) * x) ;
 
 }
 
@@ -474,9 +461,6 @@ double C2_g3_highenergy_highscaleLL(double x, double mQ , double mMu) {
 
     if(x>=1 || x<0) return 0;
 
-    double pi2 = M_PI * M_PI;
-    double pi3 = M_PI * pi2;
-
     double LQ = log(1. / mQ);
     double L2Q = LQ * LQ;
     double L3Q = LQ * L2Q;
@@ -496,7 +480,7 @@ double C2_g3_highenergy_highscaleLL(double x, double mQ , double mMu) {
 
     double c_L2Mu = 32./3. * LQ + 16./3.;
 
-    return - CA * CA * log(x) / (64 * pi3) * (
+    return - CA * CA * log(x) * (
         c_L3Q * L3Q + c_L2Q * L2Q + c_LQ * LQ
         + c_const + c_LMu * LMu + c_L2Mu * L2Mu
     ) / x;
@@ -513,19 +497,19 @@ double C2_g3_highenergy_highscale(double x, double mQ, double mMu, int nf) {
 
     if(x>=1 || x<0) return 0;
 
-    double pi2 = M_PI * M_PI;
-
     double Lmu = log(mMu);
     double Lmu2 = Lmu * Lmu;
+
+    double pi2 = M_PI * M_PI ;
 
     double LQ = log(mQ);
     double LQ2 = LQ * LQ;
     double LQ3 = LQ2 * LQ;
     double LQ4 = LQ3 * LQ;
 
-    double a11 = CA / M_PI;
-    double a21 = nf * (26 * CF - 23 * CA) / 36. / pi2;
-    double a10 = - (11. * CA + 2 * nf * (1. - 2. * CF / CA)) / 12. / M_PI;
+    double a11 = CA ;
+    double a21 = nf * (26 * CF - 23 * CA) / 36. ;
+    double a10 = - (11. * CA + 2 * nf * (1. - 2. * CF / CA)) / 12. ;
 
     double beta0 = beta(0, nf) ;
 
@@ -566,7 +550,7 @@ double C2_g3_highenergy_highscale(double x, double mQ, double mMu, int nf) {
         )
     );
 
-    return tmp / M_PI / x;
+    return 64 * tmp / x;
 
 }
 
@@ -611,9 +595,9 @@ double CL_g3_highenergy_highscale(double x, double mQ, double mMu, int nf) {
     double LQ3 = LQ2 * LQ;
     //double LQ4=LQ3*LQ;
 
-    double a11 = CA / M_PI;
-    double a21 = nf * (26 * CF - 23 * CA) / 36 / pi2;
-    double a10 = - (11 * CA + 2 * nf * (1. - 2. * CF / CA)) / 12. / M_PI;
+    double a11 = CA ;
+    double a21 = nf * (26 * CF - 23 * CA) / 36 ;
+    double a10 = - (11 * CA + 2 * nf * (1. - 2. * CF / CA)) / 12. ;
 
     double beta0 = beta(0, nf) ;
 
@@ -639,7 +623,7 @@ double CL_g3_highenergy_highscale(double x, double mQ, double mMu, int nf) {
         )
     );
 
-    return tmp / M_PI / x;
+    return 64 * tmp / x;
 
 }
 
@@ -676,9 +660,9 @@ double C2_g3_highenergy_ERR(double x, double mQ, double mMu, int nf) {
     double J = 4 * z * L;
     double K = 4 * z * Hmpm;
 
-    double a11 = CA / M_PI;
+    double a11 = CA ;
     //double a21=nf*(26*CF - 23*CA)/36/pi2;
-    double a10 = -(11 * CA + 2 * nf * (1. - 2. * CF / CA)) / 12 / M_PI;
+    double a10 = -(11 * CA + 2 * nf * (1. - 2. * CF / CA)) / 12 ;
 
     double beta0 = beta(0, nf) ;
 
@@ -716,7 +700,7 @@ double C2_g3_highenergy_ERR(double x, double mQ, double mMu, int nf) {
         )
     );
 
-    return tmp / (12 * M_PI * x) ;
+    return 16. / 3 * tmp / x ;
 
 }
 
@@ -735,9 +719,9 @@ double C2_g3_highenergy_highscale_ERR(double x, double mQ, double mMu, int nf) {
     double LQ2 = LQ * LQ;
     double LQ3 = LQ2 * LQ;
 
-    double a11 = CA / M_PI;
+    double a11 = CA ;
     //double a21= nf*(26*CF - 23*CA)/36/pi2;
-    double a10 = -(11 * CA + 2 * nf * (1. - 2. * CF / CA)) / 12 / M_PI;
+    double a10 = -(11 * CA + 2 * nf * (1. - 2. * CF / CA)) / 12 ;
 
     double beta0 = beta(0, nf) ;
 
@@ -775,7 +759,7 @@ double C2_g3_highenergy_highscale_ERR(double x, double mQ, double mMu, int nf) {
         )
     );
 
-    return tmp / M_PI / x;
+    return 64 * tmp / x;
 
 }
 

--- a/src/HighScaleCoefficientFunctions.cc
+++ b/src/HighScaleCoefficientFunctions.cc
@@ -467,8 +467,6 @@ double DL_g3_highscale(double z, double mQ, double mMu, int nf) {
     double L_Q = log(1./mQ) + L_M ;
     double L_Q2 = L_Q * L_Q ;
 
-    double pi3 = M_PI * M_PI * M_PI ;
-
     // Allocate pointers for the harmonic polylogs
     double wx = z;
     int    nw = 4;
@@ -896,8 +894,6 @@ double DL_ps3_highscale(double z, double mQ, double mMu, int nf) {
     double L_Q = log(1. / mQ) + L_M ;
     double L_Q2 = L_Q * L_Q ;
 
-    double pi3 = M_PI * M_PI * M_PI ;
-
     // Allocate pointers for the harmonic polylogs
     double wx = z;
     int    nw = 4;
@@ -1078,8 +1074,6 @@ double D2_g3_highscale_incomplete(double x, double mQ, double mMu, int nf) {
     double Lmmu = log(mMu);
     double Lmmu2 = Lmmu * Lmmu;
     //double Lmmu3=Lmmu2*Lmmu;
-
-    double pi3 = M_PI * M_PI * M_PI ;
 
     // Allocate pointers for the harmonic polylogs
     double wx = x;
@@ -2594,7 +2588,7 @@ double D2_g3_highscale_incomplete(double x, double mQ, double mMu, int nf) {
 
         + 8./9*zeta3 - 16./9*zeta3*x + 16./9*zeta3*x2
 
-        + C2_g3_massless(x, nf+1)/(nf + 1)
+        + C2_g3_massless(x, nf + 1) / (nf + 1)
     ) ;
 
 }
@@ -2634,8 +2628,6 @@ double D2_ps3_highscale(double x, double mQ, double mMu, int nf, int v) {
 
     double Lmmu = log(mMu);
     double Lmmu2 = Lmmu * Lmmu;
-
-    double pi3 = M_PI * M_PI * M_PI;
 
     // Allocate pointers for the harmonic polylogs
     double wx = x;
@@ -3311,6 +3303,7 @@ double D2_ps3_highscale(double x, double mQ, double mMu, int nf, int v) {
         H1 * x2 - 16./3 * H01 - 16./3 * H01 * x)
 
         + a_Qq_PS_30(x, Hr1, Hr2, Hr3, Hr4, Hr5, v)
+
         + 1. / (1 + nf) * C2_ps3_massless(x, 1 + nf)
 
     ) ;

--- a/src/HighScaleCoefficientFunctions.cc
+++ b/src/HighScaleCoefficientFunctions.cc
@@ -20,8 +20,9 @@ double C2_g1_highscale(double x, double mQ) {
 
     return (
         4. * TR * (
-            - 8. * x * x + 8. * x - 1. + log((1. - x) / x) * (2 * x * x - 2 * x + 1.)
-        ) / 4. / M_PI
+            - 8. * x * x + 8. * x - 1.
+            + log((1. - x) / x) * (2 * x * x - 2 * x + 1.)
+        )
         + 2. * K_Qg1(x, mQ)
     ) ;
 
@@ -36,7 +37,7 @@ double CL_g1_highscale(double x) {
 
     if(x>=1 || x<0) return 0.;
 
-    return TR * 16. * x * (1. - x) / 4. / M_PI ;  //=CL_g1_massless(x,nf)/nf
+    return TR * 16. * x * (1. - x) ;  //=CL_g1_massless(x,nf)/nf
 
 }
 
@@ -77,7 +78,7 @@ double C2_g2_highscale(double x, double mQ, double mMu) {
 
     return (
         D2_g2_highscale(x, mQ, mMu)
-        + 1. / 6 / M_PI * Lmu * C2_g1_highscale(x, mQ)
+        + 2. / 3 * Lmu * C2_g1_highscale(x, mQ)
     ) ;
 
 }
@@ -100,8 +101,6 @@ double C2_ps2_highscale(double z, double mQ, double mMu) {
     double L_M2 = L_M * L_M ;
     double L_Q = log(1. / mQ) + L_M ;
     double L_Q2 = L_Q * L_Q ;
-
-    double pi2 = M_PI * M_PI ;
 
     double H0 = H(z, 0) ;
     double H1 = H(z, 1) ;
@@ -140,7 +139,7 @@ double C2_ps2_highscale(double z, double mQ, double mMu) {
             32 * H0 * z2 + (z + 1) * (-16 * H0 * H0 - 16 * H01 + 16 * zeta2)
             - 16 * (z - 1) * (4 * z2 - 26 * z + 13) / (9 * z)
             + 8 * (z - 1) * (4 * z2 + 7 * z + 4) * H1 / (3 * z))
-    ) / (16. * pi2) ;
+    ) ;
 }
 
 //==========================================================================================//
@@ -154,7 +153,7 @@ double CL_g2_highscale(double x, double mQ, double mMu) {
 
     return (
         DL_g2_highscale(x, mQ, mMu)
-        + 1. / 6 / M_PI * Lmu * CL_g1_highscale(x)
+        + 2. / 3 * Lmu * CL_g1_highscale(x)
     ) ;
 
 }
@@ -183,8 +182,6 @@ double D2_g2_highscale(double x, double mQ, double mMu) {
 
     double x2 = x * x;
     double x3 = x2 * x;
-
-    double pi2 = M_PI * M_PI ;
 
     double H0 = H(x, 0) ;
     double H1 = H(x, 1) ;
@@ -311,7 +308,7 @@ double D2_g2_highscale(double x, double mQ, double mMu) {
             - 8 * H01 + 144 * H01 * x - 148 * H01 * x2 + 48 * H010 * x - 16 * H010 * x2 + 48 * H011 * x
             - 16 * H011 * x2 + 8 * H001 + 64 * H001 * x - 16 * H001 * x2
         )
-    ) / (16 * pi2);
+    ) ;
 }
 
 //==========================================================================================//
@@ -343,8 +340,6 @@ double DL_g2_highscale(double z, double mQ, double mMu) {
     double L_M = log(mMu) ;
     double L_Q = log(1./mQ) + L_M ;
 
-    double pi2 = M_PI * M_PI ;
-
     double H0 = H(z, 0) ;
     double H1 = H(z, 1) ;
     double Hm1 = H(z, -1);
@@ -375,7 +370,7 @@ double DL_g2_highscale(double z, double mQ, double mMu) {
             - 32. * z * H01 + (16. * (z - 1.) * (2. * z + 1.)
             - 32. * z * H0) * L_M + 32. / 15 * z * (12. * z2 + 5.) * zeta2
         )
-    ) / (16. * pi2) ;
+    ) ;
 
 }
 
@@ -393,8 +388,6 @@ double DL_ps2_highscale(double z, double mQ, double mMu) {
     double L_M = log(mMu) ;
     double L_Q = log(1./mQ) + L_M ;
 
-    double pi2 = M_PI * M_PI ;
-
     double H0 = H(z, 0) ;
     double H1 = H(z, 1) ;
     double H01 = H(z, 0, 1) ;
@@ -409,7 +402,7 @@ double DL_ps2_highscale(double z, double mQ, double mMu) {
             )
             + z * (32. * H0 * H0 + 32. * H01 - 32. * zeta2)
         )
-    ) / (16. * pi2) ;
+    ) ;
 
 }
 
@@ -425,16 +418,14 @@ double C2_g3_highscale(double x, double mQ, double mMu, int nf, int v) {
     double Lmu = log(mMu);
     double L2mu = Lmu * Lmu;
 
-    double pi2 = M_PI * M_PI ;
-
     return (
         D2_g3_highscale(x, mQ, mMu, nf, v)
-        - 1. / 3 / M_PI * Lmu * D2_g2_highscale(x, mQ, mMu)
+        - 4. / 3 * Lmu * D2_g2_highscale(x, mQ, mMu)
         - (
             (16. / 9 * CA - 15. / 2 * CF)
             + (10. / 3 * CA + 2 * CF) * Lmu
             - 4. / 9 * L2mu
-        ) / 16. / pi2 * D2_g1_highscale(x, mQ)
+        ) * D2_g1_highscale(x, mQ)
     ) ;
 
 }
@@ -452,7 +443,7 @@ double C2_ps3_highscale(double x, double mQ, double mMu, int nf) {
 
     return (
         D2_ps3_highscale(x, mQ, mMu, nf)
-        - 1. / 3 / M_PI * Lmu * D2_ps2_highscale(x, mQ, mMu)
+        - 4. / 3 * Lmu * D2_ps2_highscale(x, mQ, mMu)
     );
 
 }
@@ -859,7 +850,9 @@ double DL_g3_highscale(double z, double mQ, double mMu, int nf) {
                 )
             )
         )
-    ) / 64. / pi3 + CL_g3_massless(z, nf + 1) / (nf + 1) ;
+
+        + CL_g3_massless(z, nf + 1) / (nf + 1)
+    ) ;
 
 }
 
@@ -873,16 +866,14 @@ double CL_g3_highscale(double x, double mQ, double mMu, int nf) {
     double Lmu = log(mMu) ;
     double L2mu = Lmu * Lmu ;
 
-    double pi2 = M_PI * M_PI ;
-
     return (
         DL_g3_highscale(x, mQ, mMu, nf)
-        - 1. / 3 / M_PI * Lmu * DL_g2_highscale(x, mQ, mMu)
+        - 4. / 3 * Lmu * DL_g2_highscale(x, mQ, mMu)
         - (
             (16. / 9 * CA - 15. / 2 * CF)
             + (10. / 3 * CA + 2 * CF) * Lmu
             - 4. / 9 * L2mu
-        ) / 16. / pi2 * DL_g1_highscale(x)
+        ) * DL_g1_highscale(x)
     );
 
 }
@@ -1043,7 +1034,9 @@ double DL_ps3_highscale(double z, double mQ, double mMu, int nf) {
                 )
             ) * L_Q
         )
-    ) / (64. * pi3) + CL_ps3_massless(z, nf + 1) / (nf + 1) ;
+
+        + CL_ps3_massless(z, nf + 1) / (nf + 1)
+    ) ;
 
 }
 
@@ -1058,7 +1051,7 @@ double CL_ps3_highscale(double x, double mQ, double mMu, int nf) {
 
     return (
         DL_ps3_highscale(x, mQ, mMu, nf)
-        - 1. / 3 / M_PI * Lmu * DL_ps2_highscale(x, mQ, mMu)
+        - 4. / 3 * Lmu * DL_ps2_highscale(x, mQ, mMu)
     );
 
 }
@@ -2600,7 +2593,9 @@ double D2_g3_highscale_incomplete(double x, double mQ, double mMu, int nf) {
         + CF*nf*(1 - 2*x + 2*x2)*(69 - 28*zeta2)//from erratum
 
         + 8./9*zeta3 - 16./9*zeta3*x + 16./9*zeta3*x2
-    ) / (64. * pi3) + C2_g3_massless(x, nf+1)/(nf + 1);
+
+        + C2_g3_massless(x, nf+1)/(nf + 1)
+    ) ;
 
 }
 
@@ -3315,9 +3310,10 @@ double D2_ps3_highscale(double x, double mQ, double mMu, int nf, int v) {
         x - 8./3 * H1 - 32./9 * H1/x + 8./3 * H1 * x + 32./9 *
         H1 * x2 - 16./3 * H01 - 16./3 * H01 * x)
 
-    ) / (64 * pi3)
-    + a_Qq_PS_30(x, Hr1, Hr2, Hr3, Hr4, Hr5, v)
-    + 1. / (1 + nf) * C2_ps3_massless(x, 1 + nf) ;
+        + a_Qq_PS_30(x, Hr1, Hr2, Hr3, Hr4, Hr5, v)
+        + 1. / (1 + nf) * C2_ps3_massless(x, 1 + nf)
+
+    ) ;
 
 }
 
@@ -3337,7 +3333,7 @@ double C2_ps3_highscale_klmv_paper(double x, double mQ, double mMu, int nf, int 
 
     return (
         D2_ps3_highscale_klmv_paper(x, mQ, mMu, nf, v)
-        - 1. / 3 / M_PI * Lmu * D2_ps2_highscale(x, mQ, mMu)
+        - 4. / 3 * Lmu * D2_ps2_highscale(x, mQ, mMu)
     );
 
 }

--- a/src/MasslessCoefficientFunctions.cc
+++ b/src/MasslessCoefficientFunctions.cc
@@ -102,7 +102,7 @@ double CL_g2_massless(double x, int nf) {
     double L0 = log(x);
     double L02 = L0 * L0;
 
-    double x1= 1. - x ;
+    double x1 = 1. - x ;
     double L1 = log(x1) ;
     double L12 = L1 * L1 ;
 

--- a/src/MasslessCoefficientFunctions.cc
+++ b/src/MasslessCoefficientFunctions.cc
@@ -16,7 +16,7 @@ double C2_g1_massless(double x, int nf) {
     return 4. * nf * TR * (
         - 8. * x * x + 8. * x - 1.
         + log((1. - x) / x) * (2. * x * x - 2. * x + 1.)
-    ) / 4. / M_PI ;
+    ) ;
 
 }
 
@@ -30,7 +30,7 @@ double CL_g1_massless(double x, int nf) {
 
     if (x>=1 || x<0) return 0;
 
-    return 16. * nf * TR * x * (1. - x) / 4. / M_PI ;
+    return 16. * nf * TR * x * (1. - x) ;
 
 }
 
@@ -48,17 +48,14 @@ double C2_g2_massless(double x, int nf) {
     double x1 = 1. - x;
     double L0 = log(x);
     double L1 = log(x1);
-    double pi2 = M_PI * M_PI;
 
-    double tmp = nf * (
+    return nf * (
         58./9. * L1 * L1 * L1 - 24 * L1 * L1 - 34.88 * L1 + 30.586
         - (25.08 + 760.3 * x + 29.65 * L1 * L1 * L1) * x1 + 1204 * x * L0 * L0
         + L0 * L1 * (293.8 + 711.2 * x + 1043 * L0)
         + 115.6 * L0 - 7.109 * L0 * L0
         + 70./9. * L0 * L0 * L0 + 11.9033 * x1 / x
     ) ;
-
-    return tmp / 16. / pi2 ;
 
 }
 
@@ -81,14 +78,13 @@ double C2_ps2_massless(double x, int nf) {
     double L1 = log(x1);
     double L12 = L1 * L1 ;
     double L13 = L12 * L1 ;
-    double pi2 = M_PI * M_PI;
 
     return nf * (
         (8./3 * L12 - 32./3 * L1 + 9.8937) * x1
         + (9.57 - 13.41 * x + 0.08 * L13) * x1 * x1 + 5.667 * x * L03
         - L02 * L1 * (20.26 - 33.93 * x) + 43.36 * x1 * L0 - 1.053 * L02
         + 40./9 * L03 + 5.2903 / x * x1 * x1
-    ) / 16. / pi2 ;
+    ) ;
 
 }
 
@@ -103,8 +99,6 @@ double CL_g2_massless(double x, int nf) {
 
     if (x>=1 || x<0) return 0;
 
-    double pi2 = M_PI * M_PI ;
-
     double L0 = log(x);
     double L02 = L0 * L0;
 
@@ -112,13 +106,11 @@ double CL_g2_massless(double x, int nf) {
     double L1 = log(x1) ;
     double L12 = L1 * L1 ;
 
-    double tmp = nf * (
+    return nf * (
         (94.74 - 49.2 * x) * x1 * L12 + 864.8 * x1 * L1
         + 1161 * x * L1 * L0 + 60.06 * x * L02 + 39.66 * x1 * L0
         - 5.333 * (1./x - 1)
     );
-
-    return tmp / 16. / pi2 ;
 
 }
 
@@ -133,21 +125,17 @@ double CL_ps2_massless(double x, int nf) {
 
     if (x>=1 || x<0) return 0;
 
-    double pi2 = M_PI * M_PI;
-
     double L0 = log(x);
     double L02 = L0 * L0;
 
     double x1 = 1. - x;
     double L1 = log(x1);
 
-    double tmp =  nf * (
+    return nf * (
         (15.94 - 5.212 * x) * x1 * x1 * L1
         + (0.421 + 1.520 * x) * L02 + 28.09 * x1 * L0
         - (2.370/x - 19.27) * x1 * x1 * x1
     ) ;
-
-    return tmp / 16. / pi2 ;
 
 }
 
@@ -198,8 +186,6 @@ double C2_g3_massless(double x, int nf) {//remember that there is a delta(x1) th
     double L14 = L13 * L1;
     double L15 = L14 * L1;
 
-    double pi3 = M_PI * M_PI * M_PI;
-
     double c_nf = (
         966./81. * L15 - 1871./18. * L14 + 89.31 * L13 + 979.2 * L12
         - 2405 * L1 + 1372 * x1 * L14 - 15729 - 310510 * x + 331570 * x2
@@ -222,13 +208,11 @@ double C2_g3_massless(double x, int nf) {//remember that there is a delta(x1) th
         * x * L02 + 520./81. * x * L03 + 20./27. * x * L04
     );*/
 
-    double tmp = (
+    return (
         c_nf * nf
         + c_nf2 * nf * nf
         //+ c_nf_fl * nf * nf * fl_g_11
     );
-
-    return tmp / 64. / pi3 ;
 
 }
 
@@ -262,8 +246,6 @@ double C2_ps3_massless(double x, int nf) {//remember that there is a delta(x1) t
     double L13 = L12 * L1;
     double L14 = L13 * L1;
 
-    double pi3 = M_PI * M_PI * M_PI;
-
     double c_nf = (
         856./81 * L14 - 6032./81 * L13 + 130.57 * L12 - 542 * L1
         + 8501 - 4714 * x + 61.5 * x2) * x1 + L0 * L1 * (8831 * L0 + 4162 * x1)
@@ -288,13 +270,11 @@ double C2_ps3_massless(double x, int nf) {//remember that there is a delta(x1) t
         + 59.59 * L0 - 320./81 * L02 * (5 + L0)
     ) * x ;*/
 
-    double tmp = (
+    return (
         c_nf * nf
         + c_nf2 * nf * nf
         //+ c_fl_nf * fl_ps_11 * nf
     );
-
-    return tmp / (64 * pi3) ;
 
 }
 
@@ -341,8 +321,6 @@ double CL_g3_massless(double x, int nf) {//remember that there is a delta(x1) th
     double L13 = L12 * L1;
     double L14 = L13 * L1;
 
-    double pi3 = M_PI * M_PI * M_PI;
-
     double c_nf = (
         (144. * L14 - 47024./27. * L13 + 6319. * L12 + 53160. * L1) * x1
         + 72549. * L0 * L1 + 88238. * L02 * L1
@@ -366,13 +344,11 @@ double CL_g3_massless(double x, int nf) {//remember that there is a delta(x1) th
         - (15.4 - 2.201 * x) * x * L02 - (71.66 - 0.121 * x) * x * L0
     ) ;*/
 
-    double tmp = (
+    return (
         c_nf * nf
         + c_nf2 * nf * nf
         //+ c_nf_fl * nf * nf * fl_g_11
     ) ;
-
-    return tmp / 64. / pi3 ;
 
 }
 
@@ -402,8 +378,6 @@ double CL_ps3_massless(double x, int nf) {//remember that there is a delta(x1) t
     double L12 = L1 * L1;
     double L13 = L12 * L1;
 
-    double pi3 = M_PI * M_PI * M_PI;
-
     double c_nf =  (
         (1568./27 * L13 - 3968./9 * L12 + 5124 * L1) * x1 * x1
         + (2184 * L0 + 6059 * x1) * L0 * L1
@@ -424,12 +398,10 @@ double CL_ps3_massless(double x, int nf) {//remember that there is a delta(x1) t
         + L0)) * x
     );*/
 
-    double tmp = (
+    return (
         c_nf * nf
         + c_nf2 * nf * nf
         //+ c_fl_nf * fl_ps_11 * nf
     ) ;
-
-    return tmp / (64. * pi3) ;
 
 }

--- a/src/MatchingConditions.cc
+++ b/src/MatchingConditions.cc
@@ -16,7 +16,7 @@ double K_Qg1(double x, double mMu) {
 
     return 2 * TR * (
         x * x + (x - 1) * (x - 1)
-    ) * log(1. / mMu) / 4. / M_PI ;
+    ) * log(1. / mMu) ;
 }
 
 //==========================================================================================//
@@ -26,7 +26,7 @@ double K_Qg1(double x, double mMu) {
 //------------------------------------------------------------------------------------------//
 
 double K_gg1_local(double mMu) {
-    return - 4. / 3. * TR * log(1. / mMu) / 4. / M_PI ;
+    return - 4. / 3. * TR * log(1. / mMu) ;
 }
 
 //==========================================================================================//
@@ -56,8 +56,6 @@ double K_Qg2(double x, double mMu) {
     double Li3minus = Li3(-x) ;
     double S12xm = S12(1. - x) ;
     double S12minus = S12(-x) ;
-
-    double pi2 = M_PI * M_PI ;
 
     double Lmu = log(mMu) ;
     double Lmu2 = Lmu * Lmu ;
@@ -122,10 +120,9 @@ double K_Qg2(double x, double mMu) {
 
     double const_tot = CF * TR * const_CFTR + CA * TR * const_CATR;
 
-
     double tmp = const_tot + logmu * Lmu + logmu2 * Lmu2;
 
-    return 0.5 * tmp / 16. / pi2 ;
+    return 0.5 * tmp ;
 
 }
 
@@ -151,8 +148,6 @@ double a_Qg_30(double x, int v) {
     double L12 = L1 * L1;
     double L13 = L12 * L1;
 
-    double pi3 = M_PI * M_PI * M_PI ;
-
     if(v==0) {
         return 0.5 * (a_Qg_30(x, 1) + a_Qg_30(x, 2));
     }
@@ -160,24 +155,24 @@ double a_Qg_30(double x, int v) {
         return (
             354.1002 * L13 + 479.3838 * L12 - 7856.784 * (2. - x)
             - 6233.530 * L2 + 9416.621 / x + 1548.891 / x * L
-        ) / (64. * pi3) ;
+        ) ;
     }
     else if(v==2) {//Updated version w.r.t v==4
         return (
             226.3840 * L13 - 652.2045 * L12 - 2686.387 * L1 - 7714.786 * (2. - x)
             - 2841.851 * L2 + 7721.120 / x + 1548.891 / x * L
-        ) / (64. * pi3) ;
+        ) ;
     }
     else if(v==3) { // do not use this version
         return (
             L / x * CA * CA * (41984./243 + 160./9 * zeta2 - 224./9 * zeta3)
-        ) / (64. * pi3) ;
+        ) ;
     }
     else if(v==4) { //Version of the paper (used only for benchamrk)
         return (
             - 2658.323 * L12 - 7449.948 * L1 - 7460.002 * (2. - x)
             + 3178.819 * L2 + 4710.725 / x + 1548.891 / x * L
-        ) / (64. * pi3) ;
+        ) ;
     }
     else {
         cout<<"a_Qg_30: Choose either v=0, v=1, v=2, v=3 or v=4 !!\nExiting!!\n"<<endl;
@@ -209,8 +204,6 @@ double a_Qq_PS_30(double x, double* Hr1, double* Hr2, double* Hr3, double* Hr4, 
     double x2 = x * x ;
     double L1 = - H1 ;
 
-    double pi3 = M_PI * M_PI * M_PI ;
-
     if(v==1) {
         return (
             (1. - x) * (
@@ -218,7 +211,7 @@ double a_Qq_PS_30(double x, double* Hr1, double* Hr2, double* Hr3, double* Hr4, 
                 - 31729.716 * x2 + 66638.193 * x + 2825.641 / x
             )
             + 41850.518 * x * H0 + 688.396 / x * H0
-        ) / (64. * pi3);
+        );
     }
     else if(v==2) {
        return (
@@ -227,7 +220,7 @@ double a_Qq_PS_30(double x, double* Hr1, double* Hr2, double* Hr3, double* Hr4, 
                 + 3780.192 / x
             )
             + 8571.165 * x * H0 - 2346.893 * H0 * H0 + 688.396 / x * H0
-        ) / (64. * pi3) ;
+        ) ;
     }
     else if(v==0){
 
@@ -654,7 +647,7 @@ double a_Qq_PS_30(double x, double* Hr1, double* Hr2, double* Hr3, double* Hr4, 
             )
         ) ;
 
-        return (aQqPS30 + tildeaQqPS30) / (64. * pi3) ;
+        return aQqPS30 + tildeaQqPS30 ;
     }
     else {
         std::cout<<"Choose either v=1, v=2!!\nExiting!!\n"<<std::endl;

--- a/src/SpecialFunctions.cc
+++ b/src/SpecialFunctions.cc
@@ -13,14 +13,13 @@ using namespace std;
 //------------------------------------------------------------------------------------------//
 
 double beta(int ord, int nf) {
-    if(ord == 0) return (11. / 3 * CA - 2. / 3 * nf) / 4. / M_PI ;
+    if(ord == 0) return (11. / 3 * CA - 2. / 3 * nf) ;
     if(ord == 1) {
         double TF = TR * nf ;
         double b_ca2 = 34. / 3. * CA * CA ;
         double b_ca = -20. / 3. * CA * TF ;
         double b_cf = -4. * CF * TF ;
-        double beta_1 = b_ca2 + b_ca + b_cf ;
-        return beta_1 / (16. * M_PI * M_PI);
+        return b_ca2 + b_ca + b_cf ;
     }
     else {
         cout << "beta("<<ord<<") is not implemented"<<endl;

--- a/src/SplittingFunctions.cc
+++ b/src/SplittingFunctions.cc
@@ -68,7 +68,7 @@ double pggsing(double x) {
 
 double Pgq0(double x) {
 
-    return 2. * CF * pgq(x) / 4. / M_PI ;
+    return 2. * CF * pgq(x) ;
 
 }
 
@@ -81,7 +81,7 @@ double Pgq0(double x) {
 
 double Pqg0(double x, int nf) {
 
-    return 2. * nf * pqg(x) / 4. / M_PI ;
+    return 2. * nf * pqg(x) ;
 
 }
 
@@ -93,7 +93,7 @@ double Pqg0(double x, int nf) {
 
 double Pgg0reg(double x) {
 
-    return CA * 4. * pggreg(x) / 4. / M_PI ;
+    return CA * 4. * pggreg(x) ;
 
 }
 
@@ -105,9 +105,7 @@ double Pgg0reg(double x) {
 
 double Pgg0loc(int nf) {
 
-    double tmp = 11. / 3 * CA - 2. / 3 * nf ;
-
-    return tmp / 4. / M_PI ;
+    return 11. / 3 * CA - 2. / 3 * nf ;
 
 }
 
@@ -119,7 +117,7 @@ double Pgg0loc(int nf) {
 
 double Pgg0sing (double x) {
 
-    return 4. * CA * pggsing(x) / 4. / M_PI ;
+    return 4. * CA * pggsing(x) ;
 
 }
 
@@ -133,7 +131,7 @@ double Pqq0reg(double x) {
 
     if (x<0 || x>=1) return 0. ;
 
-    return CF * 2. * (- 1 - x) / 4 / M_PI ;
+    return CF * 2. * (- 1 - x) ;
 
 }
 
@@ -143,7 +141,7 @@ double Pqq0reg(double x) {
 
 double Pqq0loc() {
 
-    return CF * 3. / 4 / M_PI ;
+    return CF * 3. ;
 
 }
 
@@ -157,7 +155,7 @@ double Pqq0sing(double x) {
 
     if (x<0 || x>=1) return 0. ;
 
-    return CF * 2. * 2. / (1 - x) / 4. / M_PI ;
+    return CF * 2. * 2. / (1 - x) ;
 
 }
 
@@ -179,8 +177,6 @@ double Pgq1(double x, int nf) {
     double Hm10 = H(x, -1, 0) ;
     double H01 = H(x, 0, 1) ;
     double H11 = H(x, 1, 1) ;
-
-    double norm = 16. * M_PI * M_PI ;
 
     double tmp_CACF = (
         zeta2 * 16 + 76. / 9 + 4. / x + 148. / 9 * x + 176. / 9 * x * x
@@ -206,7 +202,11 @@ double Pgq1(double x, int nf) {
         + H11 * (+ 16 - 16. / x - 8 * x)
     );
 
-    return (CA * CF * tmp_CACF + CF * nf * tmp_CFnf + CF * CF * tmp_CFCF) / norm ;
+    return (
+        CA * CF * tmp_CACF
+        + CF * nf * tmp_CFnf
+        + CF * CF * tmp_CFCF
+    );
 }
 
 //==========================================================================================//
@@ -227,8 +227,6 @@ double Pgg1reg(double x, int nf) {
     double H10 = H(x, 1, 0) ;
     double Hm10 = H(x, -1, 0) ;
     double H01 = H(x, 0, 1) ;
-
-    double norm = (16. * M_PI * M_PI) ;
 
     double gx = (67. / 18 - zeta2 + H00 + 2. * H10 + 2 * H01) ;
     double g1 = 67. / 18 - zeta2 ;
@@ -260,7 +258,7 @@ double Pgg1reg(double x, int nf) {
         + H00 * (- 8. - 8. * x)
     );
 
-    return (tmp_CAnf * CA * nf + tmp_CACA * CA * CA + tmp_CFnf * CF * nf) / norm ;
+    return (tmp_CAnf * CA * nf + tmp_CACA * CA * CA + tmp_CFnf * CF * nf) ;
 
 }
 
@@ -272,13 +270,11 @@ double Pgg1reg(double x, int nf) {
 
 double Pgg1loc(int nf) {
 
-    double norm = (16. * M_PI * M_PI) ;
-
     double tmp_CAnf = - 2. / 3 ;
     double tmp_CACA =  8. / 3 + 3. * zeta3;
     double tmp_CFnf =  - 1. / 2;
 
-    return 4. * (tmp_CAnf * CA * nf + tmp_CACA * CA * CA + tmp_CFnf * CF * nf) / norm ;
+    return 4. * (tmp_CAnf * CA * nf + tmp_CACA * CA * CA + tmp_CFnf * CF * nf) ;
 
 }
 
@@ -292,13 +288,11 @@ double Pgg1sing(double x, int nf) {
 
     if (x<0 || x>=1) return 0. ;
 
-    double norm = (16. * M_PI * M_PI) ;
-
     double g1 = 67. / 18 - zeta2 ;
 
     double tmp_CAnf =  - 10. / 9 * pggsing(x);
     double tmp_CACA =  2. * g1 * pggsing(x) ;
 
-    return 4. * (tmp_CAnf * CA * nf + tmp_CACA * CA * CA) / norm ;
+    return 4. * (tmp_CAnf * CA * nf + tmp_CACA * CA * CA) ;
 
 }

--- a/src/SplittingFunctions.cc
+++ b/src/SplittingFunctions.cc
@@ -131,7 +131,7 @@ double Pqq0reg(double x) {
 
     if (x<0 || x>=1) return 0. ;
 
-    return CF * 2. * (- 1 - x) ;
+    return CF * 2. * (- 1. - x) ;
 
 }
 
@@ -155,7 +155,7 @@ double Pqq0sing(double x) {
 
     if (x<0 || x>=1) return 0. ;
 
-    return CF * 2. * 2. / (1 - x) ;
+    return CF * 2. * 2. / (1. - x) ;
 
 }
 

--- a/src/ThresholdCoefficientFunctions.cc
+++ b/src/ThresholdCoefficientFunctions.cc
@@ -230,8 +230,6 @@ double threshold_expansion_g3_const(double mQ, double mMu) {
     double xi = 1. / mQ ;
     double Lm = log(mMu);
 
-    double pi2 = M_PI * M_PI ;
-
     double c_const_sqrt = (
         c0(xi) + 36. * CA * ln2 * ln2 - 60. * CA * ln2
         + Lm * (8. * CA * ln2 - c0_bar(xi))

--- a/src/ThresholdCoefficientFunctions.cc
+++ b/src/ThresholdCoefficientFunctions.cc
@@ -23,7 +23,7 @@ double C2_g1_threshold(double x, double mQ) {
     double beta = sqrt(1. - 4. * mQ * x / (1. - x)) ;
     double xi = 1. / mQ ;
 
-    return xi / (4 * M_PI) * TR * beta / (1. + xi / 4) / x ;
+    return xi * TR * beta / (1. + xi / 4) / x ;
 
 }
 
@@ -50,7 +50,7 @@ double threshold_expansion_g2(double x, double mQ, double mMu) {
 
     return (
         C_log2b * log2b + C_logb * logb + C_fracb / beta
-    ) / (4. * M_PI);
+    ) ;
 
 }
 
@@ -65,7 +65,7 @@ double threshold_expansion_g2_const(double mQ, double mMu) {
     return (
         c0(xi) + 36 * CA * ln2 * ln2 - 60 * CA * ln2
         + log(mMu) * (8 * CA * ln2 - c0_bar(xi))
-    ) / (4. * M_PI);
+    ) ;
 
 }
 
@@ -217,7 +217,7 @@ double threshold_expansion_g3(double x, double mQ, double mMu, int nf) {
     return (
         c_log4 * l4 + c_log3 * l3 + c_log2 * l2 + c_log * l
         + c_fracbeta / beta + c_fracbeta2 / beta / beta
-    ) / (pi2 * 16.) ;
+    ) ;
 
 }
 
@@ -237,7 +237,7 @@ double threshold_expansion_g3_const(double mQ, double mMu) {
         + Lm * (8. * CA * ln2 - c0_bar(xi))
     );
 
-    return c_const_sqrt * c_const_sqrt / (16. * pi2) ;
+    return c_const_sqrt * c_const_sqrt ;
 
 }
 


### PR DESCRIPTION
Pull request that removes all the prefactors $(4 \pi)^n$ with $n=1,2,3$ from the coefficient functions, i.e. that passes from the expansion in $\alpha_s$ to $a_s=\alpha_s/(4\pi)$.