### PR TITLE
Implement aQg30

### DIFF
--- a/examples/test.cpp
+++ b/examples/test.cpp
@@ -19,10 +19,10 @@ int main() {
     int nf = 4;
 
     ApproximateCoefficientFunction F2g(
-        3, '2', 'g', true, "abmp", 1e-3, 1e-3, 1000, "analytical", 25000
+        3, '2', 'g', true, "exact", 1e-3, 1e-3, 1000, "analytical", 25000
     );
     ApproximateCoefficientFunction FLg(
-        3, 'L', 'g', true, "abmp", 1e-3, 1e-3, 1000, "analytical", 25000
+        3, 'L', 'g', true, "exact", 1e-3, 1e-3, 1000, "analytical", 25000
     );
     ApproximateCoefficientFunction F2q(
         3, '2', 'q', true, "exact", 1e-3, 1e-3, 1000

--- a/examples/test.py
+++ b/examples/test.py
@@ -4,8 +4,8 @@ import numpy as np
 nf = 4
 m = 4.92
 
-F2g = ad.ApproximateCoefficientFunction(3, '2', 'g', True, "abmp", 1e-3, 1e-3, 1000, "analytical", 25000)
-FLg = ad.ApproximateCoefficientFunction(3, 'L', 'g', True, "abmp", 1e-3, 1e-3, 1000, "analytical", 25000)
+F2g = ad.ApproximateCoefficientFunction(3, '2', 'g', True, "exact", 1e-3, 1e-3, 1000, "analytical", 25000)
+FLg = ad.ApproximateCoefficientFunction(3, 'L', 'g', True, "exact", 1e-3, 1e-3, 1000, "analytical", 25000)
 F2q = ad.ApproximateCoefficientFunction(3, '2', 'q', True, "exact", 1e-3, 1e-3, 1000)
 FLq = ad.ApproximateCoefficientFunction(3, 'L', 'q', True, "exact", 1e-3, 1e-3, 1000)
 

--- a/inc/adani/MatchingCondition.h
+++ b/inc/adani/MatchingCondition.h
@@ -19,6 +19,8 @@
 
 #include "CoefficientFunction.h"
 
+#include <gsl/gsl_errno.h>
+#include <gsl/gsl_spline.h>
 #include <string>
 
 using std::string;
@@ -33,7 +35,7 @@ class MatchingCondition {
             const int &order, const char &entry1, const char &entry2,
             const string &version
         );
-        ~MatchingCondition(){};
+        ~MatchingCondition();
 
         int GetOrder() const { return order_; };
         char GetEntry1() const { return entry1_; };
@@ -48,6 +50,9 @@ class MatchingCondition {
         const char entry1_;
         const char entry2_;
         const string version_;
+
+        gsl_interp_accel *acc_;
+        gsl_spline *spline_;
 
         //==========================================================================================//
         //  Matching conditions O(as)

--- a/src/MatchingCondition.cc
+++ b/src/MatchingCondition.cc
@@ -13,6 +13,8 @@ using std::endl;
 //------------------------------------------------------------------------------------------//
 
 // clang-format off
+// FAKE NUMBERS
+// WAITING FOR REAL ONES
 const double aQg30_X[] = { 1e-4, 1e-3, 1e-2, 0.1, 0.2, 0.3, 0.4, 0.5,  0.6,  0.7,  0.8, 0.9, 1.0 };
 const double aQg30_VALUES[] = { 0.3, 0.4, 0.45, 0.5, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1,  0.5, 0.1, 0.0 };
 // clang-format on

--- a/src/MatchingCondition.cc
+++ b/src/MatchingCondition.cc
@@ -357,7 +357,7 @@ double MatchingCondition::a_Qg_30(double x, int v) const {
                + 10739.21741 * L;
     } else {
         cout << "Error in MatchingCondition::a_Qg_30: Choose either v=0, v=1, "
-                "v=-1, v=-12 or v=2"
+                "v=-1, v=-12, v=2 or v=3"
              << endl;
         exit(-1);
     }


### PR DESCRIPTION
Implement the exact $a_{Qg}^{(3,0)}$ from [arXiv:2403.00513].
The actual numbers are still missing since the authors (Blümlein) said that there will be a code release soon (whatever soon means).
However, here everything is implemented except for the numerical values.

The values of $a_{Qg}^{(3,0)}$ have to be produced between $x=10^{-4}$ and $x=1$.
Below $x=10^{-4}$ the small- $x$ limit (Eq. (4.4) from [arXiv:2403.00513]) is used.

Whoever is going to take care of this once that the numbers will be public, remember to recompute the grids in YADISM and to change `'gm'` to `'exact'` in all the calls to the `adani` package